### PR TITLE
[Podspec] Fix a typo causing a circular dependency

### DIFF
--- a/OMGHTTPURLRQ.podspec
+++ b/OMGHTTPURLRQ.podspec
@@ -17,9 +17,9 @@ Pod::Spec.new do |s|
   s.default_subspecs = 'RQ'
 
   s.subspec 'RQ' do |ss|
-    s.source_files = 'OMGHTTPURLRQ.{h,m}'
-    s.dependency 'OMGHTTPURLRQ/UserAgent'
-    s.dependency 'OMGHTTPURLRQ/FormURLEncode'
+    ss.source_files = 'OMGHTTPURLRQ.{h,m}'
+    ss.dependency 'OMGHTTPURLRQ/UserAgent'
+    ss.dependency 'OMGHTTPURLRQ/FormURLEncode'
   end
 
   s.subspec 'UserAgent' do |ss|


### PR DESCRIPTION
Discovered because of a circular dependency in the podspec via https://github.com/CocoaPods/Resolver/issues/6

Since the root spec is depending on the subspecs, the subspecs also depend on the root spec. Thus a circular dependency issue.
