### PR TITLE
Fix deprecation warning for watchOS target

### DIFF
--- a/Sources/OMGFormURLEncode.m
+++ b/Sources/OMGFormURLEncode.m
@@ -1,17 +1,16 @@
 #import <Foundation/Foundation.h>
 #import "OMGFormURLEncode.h"
 
-static inline NSString *enc(id in, CFStringRef ignore) {
-    return (__bridge_transfer  NSString *) CFURLCreateStringByAddingPercentEscapes(
-        kCFAllocatorDefault,
-        (__bridge CFStringRef)[in description],
-        ignore,
-        CFSTR(":/?&=;+!@#$()',*"),
-        kCFStringEncodingUTF8);
+static inline NSString *enc(id in, NSString *ignore) {
+	NSMutableCharacterSet *allowedSet = [NSMutableCharacterSet characterSetWithCharactersInString:ignore];
+	[allowedSet formUnionWithCharacterSet:[NSCharacterSet URLQueryAllowedCharacterSet]];
+	[allowedSet removeCharactersInString:@":/?&=;+!@#$()',*"];
+
+	return [[in description] stringByAddingPercentEncodingWithAllowedCharacters:allowedSet];
 }
 
-#define enckey(in) enc(in, CFSTR("[]."))
-#define encval(in) enc(in, NULL)
+#define enckey(in) enc(in, @"[]")
+#define encval(in) enc(in, @"")
 
 static NSArray *DoQueryMagic(NSString *key, id value) {
     NSMutableArray *parts = [NSMutableArray new];


### PR DESCRIPTION
This PR replaces the deprecated `CFURLCreateStringByAddingPercentEscapes` with `stringByAddingPercentEncodingWithAllowedCharacters:` using a customized `URLQueryAllowedCharacterSet` for allowed characters. This fix also makes the podspec pass the CocoaPods `lint` again.