### PR TITLE
If the parameters dictionary is nil or empty, returns nil.

### DIFF
--- a/Sources/OMGFormURLEncode.m
+++ b/Sources/OMGFormURLEncode.m
@@ -43,7 +43,7 @@ static NSArray *DoQueryMagic(NSString *key, id value) {
 
 NSString *OMGFormURLEncode(NSDictionary *parameters) {
     if (parameters.count == 0)
-        return @"";
+        return nil;
     NSMutableString *queryString = [NSMutableString new];
     NSEnumerator *e = DoQueryMagic(nil, parameters).objectEnumerator;
     for (;;) {


### PR DESCRIPTION
Example 1:
GET server.com
OMGFormURLEncode func will return
server.com? — valid

Example 2:
GET server.com?q=test
OMGFormURLEncode func will return
server.com?q=test? — error