### PR TITLE
Update code sign identity

### DIFF
--- a/OMGHTTPURLRQ.xcodeproj/project.pbxproj
+++ b/OMGHTTPURLRQ.xcodeproj/project.pbxproj
@@ -468,7 +468,8 @@
 		63EDFE871A7FFD0E0030F974 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				PRODUCT_BUNDLE_IDENTIFIER = "dev.mxcl.$(PRODUCT_NAME:rfc1034identifier)";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -478,7 +479,8 @@
 		63EDFE881A7FFD0E0030F974 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				PRODUCT_BUNDLE_IDENTIFIER = "dev.mxcl.$(PRODUCT_NAME:rfc1034identifier)";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";


### PR DESCRIPTION
This pull request changes the code signing identity setting of `OMGiOS` target to `Don't Code Sign` in order to fix carthage builds on travis ci. 