### PR TITLE
fixed static OMGFormURLEncode method to return nil when no parameters…

### DIFF
--- a/Sources/OMGFormURLEncode.m
+++ b/Sources/OMGFormURLEncode.m
@@ -43,7 +43,7 @@ static NSArray *DoQueryMagic(NSString *key, id value) {
 
 NSString *OMGFormURLEncode(NSDictionary *parameters) {
     if (parameters.count == 0)
-        return @"";
+        return nil;
     NSMutableString *queryString = [NSMutableString new];
     NSEnumerator *e = DoQueryMagic(nil, parameters).objectEnumerator;
     for (;;) {


### PR DESCRIPTION
… are given

Need to return nil because the GET method shouldn't add ? to URL if params are nil

Fix for #18 