### PR TITLE
Preserve URL when query params are nil

### DIFF
--- a/Sources/OMGHTTPURLRQ.m
+++ b/Sources/OMGHTTPURLRQ.m
@@ -71,8 +71,8 @@ static inline NSMutableURLRequest *OMGMutableURLRequest() {
 @implementation OMGHTTPURLRQ
 
 + (NSMutableURLRequest *)GET:(NSString *)urlString :(NSDictionary *)params error:(NSError **)error {
-    id queryString = OMGFormURLEncode(params);
-    if (queryString) urlString = [urlString stringByAppendingFormat:@"?%@", queryString];
+    NSString *queryString = OMGFormURLEncode(params);
+    if (queryString.length) urlString = [urlString stringByAppendingFormat:@"?%@", queryString];
 
     id url = [NSURL URLWithString:urlString];
     if (!url) {

--- a/Tests/OMGFormURLEncodeTestCase.m
+++ b/Tests/OMGFormURLEncodeTestCase.m
@@ -48,6 +48,13 @@
 }
 
 - (void)test7 {
+    id urlString = @"http://example.com";
+    NSURLRequest *rq = [OMGHTTPURLRQ GET:urlString:nil error:nil];
+    XCTAssertNil(rq.URL.query);
+    XCTAssertEqualObjects(rq.URL.absoluteString, urlString);
+}
+
+- (void)test8 {
     id params = @{@"key":@"value"};
     id rq = [OMGHTTPURLRQ POST:@"http://example.com" JSON:params error:nil];
 
@@ -56,7 +63,7 @@
     XCTAssertEqualObjects(@"{\"key\":\"value\"}", body, @"Parameters were not encoded correctly");
 }
 
-- (void)test8 {
+- (void)test9 {
     id params = @[@{@"key":@"value"}];
     id rq = [OMGHTTPURLRQ POST:@"http://example.com" JSON:params error:nil];
 


### PR DESCRIPTION
I.e. don't add a trailing "?"

Fixes #18
Closes #19
Closes #15

@mxcl please confirm (to the best of your knowledge) that this is not a breaking change and that a major version bump is not required.